### PR TITLE
Update docs and warnings to mention new settings path

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ I previously published an [add-on for importing Aseprite files](https://github.c
 1. Install it from [Godot Asset Library](https://godotengine.org/asset-library/asset/2025) or:
     - Clone this repository or download its contents as an archive.
     - Place the contents of the `addons` folder of the repository into the `addons` folder of your project.
-1. Adjust the settings in `Project Settings` -> `General` -> `Advanced Settings` -> `Importality`
+1. Adjust the settings in `Editor Settings` -> `Importality`
      - [Specify a directory for temporary files](https://github.com/nklbdev/godot-4-importality/wiki/about-temporary-files-and-ram_drives-(en)).
      - Specify the command and its parameters to launch your editor in data export mode, if necessary. How to configure settings for your graphical application, see the corresponding article on the [wiki](https://github.com/nklbdev/godot-4-importality/wiki).
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -57,7 +57,7 @@
 1. Установите его из [Библиотеки Ассетов Godot](https://godotengine.org/asset-library/asset/2025) или:
     - Склонируйте этот репозиторий или скачайте его содержимое в виде архива.
     - Поместите содержимое папки `addons` репозитория в папку `addons` вашего проекта.
-1. Настройте параметры в `Project Settings` -> `General` -> `Advanced Settings` -> `Importality`
+1. Настройте параметры в `Editor Settings` -> `Importality`
     - [Укажите директорию для временных файлов](https://github.com/nklbdev/godot-4-importality/wiki/about-temporary-files-and-ram_drives-(ru)).
     - Укажите команду и её параметры для запуска вашего редактора в режиме экспорта данных, если это необходимо. Как настроить параметры для вашего графического приложения читайте в соответствующей статье [вики](https://github.com/nklbdev/godot-4-importality/wiki), посвящённой ему.
 

--- a/addons/nklbdev.importality/setting.gd
+++ b/addons/nklbdev.importality/setting.gd
@@ -60,8 +60,8 @@ func get_value() -> GettingValueResult:
 	if __is_required:
 		if __is_value_empty_func.call(value):
 			result.fail(ERR_UNCONFIGURED,
-				"The project settging \"%s\" is not specified!" % [__name] + \
-				"Specify it in Projest Settings -> General -> Importality.")
+				"The editor setting \"%s\" is not specified! " % [__name] + \
+				"Specify it in Editor Settings -> Importality.")
 			return result
 	result.success(value)
 	return result


### PR DESCRIPTION
Addresses #21, #23, #26
Fixes #28
This PR updates the relevant documentation so that users look for Importality settings in Editor Settings rather than Project settings.
Also fixes a typo in warning and adds a space after exclamation mark.