### PR TITLE
Add a simple Godot project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.import
+/.godot/

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,19 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="Importality"
+config/features=PackedStringArray("4.0")
+config/icon="res://icon.svg"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/nklbdev.importality/plugin.cfg")


### PR DESCRIPTION
While developing #37, I found it very helpful to have a Godot project set up for the addon. Not only does this allow the addon to be easily opened in the Godot editor, it also allows external editors (e.g. [Visual Studio Code](https://github.com/godotengine/godot-vscode-plugin#vs-code)) to use Godot as a language server.

The project file is configured with compatibility with Godot 4.0 (so that Importality's supported versions of Godot don't change) and the `.godot` cache directory is ignored by Git.