### PR TITLE
Fix heading links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ In version 0.3.0, the plugin settings were moved from the ProjectSettings to the
 
 ## 📜 Table of contents
 
-- [Introduction](#introduction)
-- [Features](#features)
-- [How to install](#how-to-install)
-- [How to use](#how-to-use)
-- [How to help the project](#how-to-help-the-project)
+- [Introduction](#-introduction)
+- [Features](#-features)
+- [How to install](#-how-to-install)
+- [How to use](#-how-to-use)
+- [How to help the project](#-how-to-help-the-project)
 
 ## 📝 Introduction
 


### PR DESCRIPTION
The links currently don't work. Fixed by prefixing the anchors with an '-' so that they support the emoji that are in the headings. 