### PR TITLE
make array casting explicit

### DIFF
--- a/addons/nklbdev.importality/rect_packer.gd
+++ b/addons/nklbdev.importality/rect_packer.gd
@@ -82,7 +82,7 @@ static func pack(rects_sizes: Array[Vector2i]) -> RectPackingResult:
 	var bounds: Vector2i = rects_sizes[rects_order[0]]
 	var utilized_area: int = bounds.x * bounds.y
 
-	var splits_by_axis: Array[PackedInt32Array] = [[0, bounds.x], [0, bounds.y]]
+	var splits_by_axis: Array[PackedInt32Array] = [PackedInt32Array([0, bounds.x]), PackedInt32Array([0, bounds.y])]
 	__add_rect_to_cache(Rect2i(Vector2i.ZERO, rects_sizes[rects_order[0]]), rect_cache, rect_cache_grid_size)
 
 	for rect_index in range(1, rects_count): # skip first rect at (0, 0)


### PR DESCRIPTION
This fixes a crash when importing SpriteFrames from Aseprite files in Godot 4.6-beta2:

```
  ERROR: Attempted to set a variable of type 'Array' into a TypedArray of type 'PackedInt32Array'.
  ERROR: core/variant/array.cpp:520 - Condition "!_p->typed.validate(value, "set")" is true.
```

It appears that it's no longer possible to implicitly cast variables like this.

I've opened an issue in the godot repo ( https://github.com/godotengine/godot/issues/114299 ) and this is a workaround.